### PR TITLE
Free existing FT_Face before creating a new one

### DIFF
--- a/src/FontEngine.cpp
+++ b/src/FontEngine.cpp
@@ -110,6 +110,8 @@ void FontEngine::setDeviceResolution (int x, int y) {
  * @param[in] fontindex index of font in font collection (multi-font files, like TTC)
  * @return true on success */
 bool FontEngine::setFont (const string &fname, int fontindex, const CharMapID &charMapID) {
+	if (_currentFace && FT_Done_Face(_currentFace))
+		Message::estream(true) << "FontEngine: error removing font\n";
 	if (FT_New_Face(_library, fname.c_str(), fontindex, &_currentFace)) {
 		Message::estream(true) << "FontEngine: error reading file " << fname << '\n';
 		return false;


### PR DESCRIPTION
FontEngine was never destroying the FT_Face's it creates, except the
very last one that was destroyed by the destructor. For some reason,
this was causing FT_New_Face() to fail on Windows after processing the
first hundred or so pages of DVI files.
