### PR TITLE
Add an option not to merge adjacent chars

### DIFF
--- a/src/CommandLine.cpp
+++ b/src/CommandLine.cpp
@@ -32,6 +32,7 @@ const CmdLineParserBase::Option CommandLine::_options[] = {
 	{'l', "list-specials", ARG_NONE, new OptionHandlerImpl<CommandLine>(&CommandLine::handle_list_specials)},
 	{'M', "mag", ARG_REQUIRED, new OptionHandlerImpl<CommandLine>(&CommandLine::handle_mag)},
 	{'n', "no-fonts", ARG_OPTIONAL, new OptionHandlerImpl<CommandLine>(&CommandLine::handle_no_fonts)},
+	{'\0', "no-merge", ARG_NONE, new OptionHandlerImpl<CommandLine>(&CommandLine::handle_no_merge)},
 	{'\0', "no-mktexmf", ARG_NONE, new OptionHandlerImpl<CommandLine>(&CommandLine::handle_no_mktexmf)},
 	{'S', "no-specials", ARG_OPTIONAL, new OptionHandlerImpl<CommandLine>(&CommandLine::handle_no_specials)},
 	{'\0', "no-styles", ARG_NONE, new OptionHandlerImpl<CommandLine>(&CommandLine::handle_no_styles)},
@@ -79,6 +80,7 @@ void CommandLine::init () {
 	_list_specials_given = false;
 	_mag_given = false;
 	_no_fonts_given = false;
+	_no_merge_given = false;
 	_no_mktexmf_given = false;
 	_no_specials_given = false;
 	_no_styles_given = false;
@@ -144,6 +146,7 @@ const char** CommandLine::helplines (size_t *numlines) const {
 		"o-s, --stdout                  write SVG output to stdout",
 		"o-n, --no-fonts[=variant]      draw glyphs by using path elements [0]",
 		"o    --no-styles               don't use styles to reference fonts",
+		"o    --no-merge                don't merge adjacent text tags",
 		"o-z, --zip[=level]             create compressed .svgz file [9]",
 		"sSVG transformations:",
 		"o-r, --rotate=angle            rotate page content clockwise",
@@ -240,6 +243,10 @@ void CommandLine::handle_mag (InputReader &ir, const Option &opt, bool longopt) 
 void CommandLine::handle_no_fonts (InputReader &ir, const Option &opt, bool longopt) {
 	if (ir.eof() || getIntArg(ir, opt, longopt, _no_fonts_arg))
 		_no_fonts_given = true;
+}
+
+void CommandLine::handle_no_merge (InputReader &ir, const Option &opt, bool longopt) {
+	_no_merge_given = true;
 }
 
 void CommandLine::handle_no_mktexmf (InputReader &ir, const Option &opt, bool longopt) {

--- a/src/CommandLine.h
+++ b/src/CommandLine.h
@@ -41,6 +41,7 @@ class CommandLine : public CmdLineParserBase
 		double mag_arg () const {return _mag_arg;}
 		bool no_fonts_given () const {return _no_fonts_given;}
 		int no_fonts_arg () const {return _no_fonts_arg;}
+		bool no_merge_given () const {return _no_merge_given;}
 		bool no_mktexmf_given () const {return _no_mktexmf_given;}
 		bool no_specials_given () const {return _no_specials_given;}
 		const std::string& no_specials_arg () const {return _no_specials_arg;}
@@ -95,6 +96,7 @@ class CommandLine : public CmdLineParserBase
 		void handle_list_specials (InputReader &ir, const Option &opt, bool longopt);
 		void handle_mag (InputReader &ir, const Option &opt, bool longopt);
 		void handle_no_fonts (InputReader &ir, const Option &opt, bool longopt);
+		void handle_no_merge (InputReader &ir, const Option &opt, bool longopt);
 		void handle_no_mktexmf (InputReader &ir, const Option &opt, bool longopt);
 		void handle_no_specials (InputReader &ir, const Option &opt, bool longopt);
 		void handle_no_styles (InputReader &ir, const Option &opt, bool longopt);
@@ -142,6 +144,7 @@ class CommandLine : public CmdLineParserBase
 		double _mag_arg;
 		bool _no_fonts_given;
 		int _no_fonts_arg;
+		bool _no_merge_given;
 		bool _no_mktexmf_given;
 		bool _no_specials_given;
 		std::string _no_specials_arg;

--- a/src/SVGTree.cpp
+++ b/src/SVGTree.cpp
@@ -40,6 +40,7 @@ bool SVGTree::CREATE_STYLE=true;
 bool SVGTree::USE_FONTS=true;
 bool SVGTree::CREATE_USE_ELEMENTS=false;
 bool SVGTree::RELATIVE_PATH_CMDS=false;
+bool SVGTree::MERGE_CHARS=true;
 double SVGTree::ZOOM_FACTOR=1.0;
 
 
@@ -136,12 +137,12 @@ void SVGTree::appendChar (int c, double x, double y, const Font &font) {
 	XMLElementNode *node=_span;
 	if (USE_FONTS) {
 		// changes of fonts and transformations require a new text element
-		if (!_text || _font.changed() || _matrix.changed() || _vertical.changed()) {
+		if (!MERGE_CHARS || !_text || _font.changed() || _matrix.changed() || _vertical.changed()) {
 			newTextNode(x, y);
 			node = _text;
 			_color.changed(true);
 		}
-		if (_xchanged || _ychanged || (_color.changed() && _color.get() != Color::BLACK)) {
+		if (MERGE_CHARS && (_xchanged || _ychanged || (_color.changed() && _color.get() != Color::BLACK))) {
 			// if drawing position was explicitly changed, create a new tspan element
 			_span = new XMLElementNode("tspan");
 			if (_xchanged) {
@@ -171,6 +172,10 @@ void SVGTree::appendChar (int c, double x, double y, const Font &font) {
 			node = _text;
 		}
 		node->append(XMLString(font.unicode(c), false));
+		if (!MERGE_CHARS && _color.get() != font.color()) {
+			node->addAttribute("fill", _color.get().rgbString());
+			_color.changed(false);
+		}
 	}
 	else {
 		if (_color.changed() || _matrix.changed()) {

--- a/src/SVGTree.h
+++ b/src/SVGTree.h
@@ -93,6 +93,7 @@ class SVGTree
 		static bool CREATE_STYLE;        ///<  use style elements and class attributes to reference fonts?
 		static bool CREATE_USE_ELEMENTS; ///< allow generation of <use/> elements?
 		static bool RELATIVE_PATH_CMDS;  ///< relative path commands rather than absolute ones?
+		static bool MERGE_CHARS;         ///< whether to merge chars with common properties into the same <text> tag
 		static double ZOOM_FACTOR;       ///< factor applied to width/height attribute
 
 	protected:

--- a/src/dvisvgm.cpp
+++ b/src/dvisvgm.cpp
@@ -351,6 +351,7 @@ int main (int argc, char *argv[]) {
 	SVGTree::CREATE_USE_ELEMENTS = args.no_fonts_arg() < 1;
 	SVGTree::ZOOM_FACTOR = args.zoom_arg();
 	SVGTree::RELATIVE_PATH_CMDS = args.relative_given();
+	SVGTree::MERGE_CHARS = !args.no_merge_given();
 	DVIToSVG::TRACE_MODE = args.trace_all_given() ? (args.trace_all_arg() ? 'a' : 'm') : 0;
 	Message::LEVEL = args.verbosity_arg();
 	PhysicalFont::EXACT_BBOX = args.exact_given();

--- a/src/options.xml
+++ b/src/options.xml
@@ -74,6 +74,9 @@
 			<option long="no-styles">
 				<description>don't use styles to reference fonts</description>
 			</option>
+			<option long="no-merge">
+				<description>don't merge adjacent text tags</description>
+			</option>
 			<option long="zip" short="z">
 				<arg type="int" name="level" default="9" optional="yes"/>
 				<description>create compressed .svgz file</description>


### PR DESCRIPTION
With this option on, each DVI character is put in its own <text> tag.
Makes post processing the SVG file a bit simpler.
