### PR TITLE
Auto-detect ghostscript dynamic library on macOS

### DIFF
--- a/src/Ghostscript.cpp
+++ b/src/Ghostscript.cpp
@@ -112,15 +112,26 @@ static string get_libgs (const string &fname) {
 	// try to find libgs.so.X on the user's system
 	const int abi_min=7, abi_max=9; // supported libgs ABI versions
 	for (int i=abi_max; i >= abi_min; i--) {
-		ostringstream oss;
+		{
+			ostringstream oss;
 #if defined(__CYGWIN__)
-		oss << "cyggs-" << i << ".dll";
+			oss << "cyggs-" << i << ".dll";
 #else
-		oss << "libgs.so." << i;
+			oss << "libgs.so." << i;
 #endif
-		DLLoader loader(oss.str().c_str());
-		if (loader.loaded())
-			return oss.str();
+			DLLoader loader(oss.str().c_str());
+			if (loader.loaded())
+				return oss.str();
+		}
+#if defined(__APPLE__)
+		{
+			ostringstream oss;
+			oss << "libgs." << i << ".dylib";
+			DLLoader loader(oss.str().c_str());
+			if (loader.loaded())
+				return oss.str();
+		}
+#endif
 	}
 #endif
 	// no appropriate library found


### PR DESCRIPTION
I've added in handling to look for `*.dylib` dynamic libraries after `*.so.*` shares libraries on macOS only. Here's how `dvisvgm` behaves on my system (macOS Sierra 10.12.4), before the change:

```
$ otool -L ./src/dvisvgm
./src/dvisvgm:
    /usr/local/opt/freetype/lib/libfreetype.6.dylib (compatibility version 20.0.0, current version 20.0.0)
    /usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.8)
    /usr/local/opt/potrace/lib/libpotrace.0.dylib (compatibility version 1.0.0, current version 1.3.0)
    /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1238.51.1)
    /usr/local/dvisvgm/lib/libkpathsea.6.dylib (compatibility version 9.0.0, current version 9.3.0)
    /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 307.5.0)
$ ./src/dvisvgm -V1
dvisvgm 2.1.3 (x86_64-apple-darwin16.5.0)
------------------------------------------
brotli:    1.0.0
clipper:   6.2.1
fontforge: 20160721
freetype:  2.7.1
kpathsea:  6.2.3
potrace:   1.13
xxhash:    0.6.2
zlib:      1.2.8
$ ./src/dvisvgm test
processing of PostScript specials is disabled (Ghostscript not found)
pre-processing DVI file (format version 2)
processing page 1
  WARNING: 37 PostScript specials ignored. The resulting SVG might look wrong.
  page is empty
  graphic size: 0pt x 0pt (0mm x 0mm)
  output written to test.svg
1 of 1 page converted in 0.418088 seconds
```
And after the change:
```
$ otool -L ./src/dvisvgm
./src/dvisvgm:
    /usr/local/opt/freetype/lib/libfreetype.6.dylib (compatibility version 20.0.0, current version 20.0.0)
    /usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.8)
    /usr/local/opt/potrace/lib/libpotrace.0.dylib (compatibility version 1.0.0, current version 1.3.0)
    /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1238.51.1)
    /usr/local/dvisvgm/lib/libkpathsea.6.dylib (compatibility version 9.0.0, current version 9.3.0)
    /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 307.5.0)
$ ./src/dvisvgm -V1
dvisvgm 2.1.3 (x86_64-apple-darwin16.5.0)
------------------------------------------
brotli:      1.0.0
clipper:     6.2.1
fontforge:   20160721
freetype:    2.7.1
Ghostscript: 9.21
kpathsea:    6.2.3
potrace:     1.13
xxhash:      0.6.2
zlib:        1.2.8
$ ./src/dvisvgm test
pre-processing DVI file (format version 2)
processing page 1
  graphic size: 171.121pt x 171.121pt (60.1423mm x 60.1423mm)
  output written to test.svg
1 of 1 page converted in 0.543811 seconds
```

I also ran the tests, in the first case two tests that depend on ghostscript fail, after the fix all tests pass.

(Based on other includes in the texlive source tree, I believe `__APPLE__` is the correct define to use.)