### PR TITLE
JFM.cpp: support new JFM spec introduced in TeX Live r46452

### DIFF
--- a/src/JFM.cpp
+++ b/src/JFM.cpp
@@ -66,10 +66,12 @@ JFM::JFM (istream &is) {
 
 void JFM::readTables (StreamReader &reader, int nt, int nw, int nh, int nd, int ni) {
 	// determine smallest charcode with chartype > 0
-	uint16_t minchar=0xFFFF, maxchar=0;
+	uint32_t minchar=0x10FFFF, maxchar=0;
 	for (int i=0; i < nt; i++) {
-		uint16_t c = (uint16_t)reader.readUnsigned(2);
-		uint16_t t = (uint16_t)reader.readUnsigned(2);
+		// support new JFM spec by texjporg
+		uint32_t c = (uint32_t)reader.readUnsigned(2);
+		c += 65536 * (uint32_t)reader.readUnsigned(1);
+		uint16_t t = (uint16_t)reader.readUnsigned(1);
 		if (t > 0) {
 			minchar = min(minchar, c);
 			maxchar = max(maxchar, c);
@@ -82,8 +84,10 @@ void JFM::readTables (StreamReader &reader, int nt, int nw, int nh, int nd, int 
 		memset(&_charTypeTable[0], 0, nt*sizeof(uint16_t));
 		reader.seek(-nt*4, ios::cur);
 		for (int i=0; i < nt; i++) {
-			uint16_t c = (uint16_t)reader.readUnsigned(2);
-			uint16_t t = (uint16_t)reader.readUnsigned(2);
+			// support new JFM spec by texjporg
+			uint32_t c = (uint32_t)reader.readUnsigned(2);
+			c += 65536 * (uint32_t)reader.readUnsigned(1);
+			uint16_t t = (uint16_t)reader.readUnsigned(1);
 			if (c >= minchar)
 				_charTypeTable[c-minchar] = t;
 		}


### PR DESCRIPTION
We (Japanese TeX Development Community) introduced a new JFM format spec in [TeX Live r46452](https://www.tug.org/svn/texlive?view=revision&revision=46452).

Here is a documentation in texk/web2c/ptexdir/ppltotf.ch:

````
In the original JFM spec by ASCII Corporation, |jis_code| and |char_type|
were packed into upper (2~bytes) and lower (2~bytes) halfword respectively.
However, |char_type| is allowed only 0..255,
so the upper byte of lower halfword was always 0.

In the new JFM spec by texjporg, |jis_code| ``XXyyzz'' is packed into
first 3~bytes in the form ``yy zz XX'', and |char_type| is packed into
remaining 1~byte. The new spec is effectively upper compatible with
the original, and it allows |jis_code| larger than 0x10000 (not really
useful for me \.{pPLtoTF} but necessary for \.{upPLtoTF}).
````

This pull request is a patch for supporting the new JFM spec in dvisvgm. Thanks --Hironobu