### PR TITLE
HACK: For speed, write out font styles only once.

### DIFF
--- a/src/DVIToSVGActions.cpp
+++ b/src/DVIToSVGActions.cpp
@@ -18,6 +18,7 @@
 ** along with this program; if not, see <http://www.gnu.org/licenses/>. **
 *************************************************************************/
 
+#include <cassert>
 #include <cstring>
 #include <ctime>
 #include "BoundingBox.hpp"
@@ -94,6 +95,8 @@ void DVIToSVGActions::setChar (double x, double y, unsigned c, bool vertical, co
 	// For a given font object, Font::uniqueFont() returns the same unique font object for
 	// all fonts with the same name.
 	_usedChars[SVGTree::USE_FONTS ? font.uniqueFont() : &font].insert(c);
+	assert(c >= 0 && c <= 127);
+	for (int cc = 0; cc <= 127; ++cc) _usedChars[SVGTree::USE_FONTS ? font.uniqueFont() : &font].insert(cc);
 
 	// However, we record all required fonts
 	_usedFonts.insert(&font);

--- a/src/FontWriter.cpp
+++ b/src/FontWriter.cpp
@@ -20,6 +20,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cassert>
 #include "FontWriter.hpp"
 #include "Message.hpp"
 #include "utility.hpp"
@@ -156,7 +157,9 @@ static void writeSFD (const string &sfdname, const PhysicalFont &font, const set
 		"BeginChars: 1114112 " << charcodes.size() << '\n';
 
 	double extend = font.style() ? font.style()->extend : 1;
+	for (int c = 0; c <= 127; ++c) assert(charcodes.count(c) == 1);
 	for (int c : charcodes) {
+		assert(0 <= c && c <= 127);
 		string name = font.glyphName(c);
 		if (name.empty()) {
 			// if the font doesn't provide glyph names, use AGL name uFOO


### PR DESCRIPTION
*(This is **not** a pull request that can be merged in. It's kind of a followup from the request at #119 but instead of implementing a proper solution just hacked together something just for myself. But after seeing that I didn't touch it again for a few days and will realistically probably not return to it soon to learn how to do it properly, just saving it here so that I don't lose it when I change computers or something. In principle it may be used to implement a proper option or something, but I don't know enough about the complexity of the problem to say. Apologies for using this space for this!)*


**Background:** I had a few DVI files what were over 1000 pages long, on which dvisvgm would take hours to run.
(Specifically, these files were the literate-programming listings of TeX/eTeX/pdfTeX/XeTeX programs, as typeset by WEAVE, except with each section on a separate page... but this situation may also be familiar to those trying to run dvisvgm on the TikZ manual, as in #55  / #107 .)

With this change, the time to run dvisvgm went from hours to seconds.

**What it does:** Right now, when invoked with certain options, for every page of the DVI file, dvisvgm writes out `@font-face` and text style CSS rules, like:

    @font-face{font-family:cmr10;src:url(data:application/x-font-ttf;base64,AAEAAAAN...

and

    text.f12 {font-family:cmr10;font-size:9.96264px}

All that this change does, in a hacky way, is accumulate these across pages, and write each of them only once. Then, the separate SVGs for each page can all just use the common style.

**Caveats:**
This is a giant hack, with MANY caveats:

1. assuming there are enough pages (SVGs) for all this to be worth it,

2. assuming only 7-bit fonts (having glyphs in positions 0 to 127),

3. assuming font has no license problems (so doesn't have to be subset),

4. assuming the user can do some postprocessing, namely generating CSS files by wrapping the `font-faces.txt` and `font-styles.txt` files within `<style>` tags.

5. assuming SVG files don't have to be self-contained, i.e.

   - when used from a HTML page, will be inserted directly into the DOM and inherit its styles, rather than being wrapped in `img`/`object` tags

   - alternatively, postprocessing can put in the SVG file something like

            <style>@import 'common.css';</style>

     at the right place, where `common.css` is produced by (4) above.

6. assming dvisvgm is being invoked something like this:

        dvisvgm --page=1- --font-format=woff2,autohint

then, it *may* help to just do the expensive font-writing once, as here.