### PR TITLE
Add DVISVGM_PATH for finding missing l3backend-dvips.pro.

### DIFF
--- a/src/FileFinder.cpp
+++ b/src/FileFinder.cpp
@@ -56,6 +56,10 @@ bool FileFinder::_enableMktex = false;
  *  @param[in] enable_mktexmf if true, tfm and mf file generation is activated */
 FileFinder::FileFinder () {
 	addLookupDir(".");  // always lookup files in the current working directory
+        char *path=getenv("DVISVGM_PATH");
+        if(path)
+          addLookupDir(path);
+
 #ifdef MIKTEX
 	_miktex = util::make_unique<MiKTeXCom>();
 #else


### PR DESCRIPTION
Updating the version of dvisvgm in TeXLive 2020 generates this error:

WARNING: PostScript header file l3backend-dvips.pro not found

This patch provides a simple workaround.