### PR TITLE
mingw: fix for gcc 11

### DIFF
--- a/src/FileSystem.cpp
+++ b/src/FileSystem.cpp
@@ -34,8 +34,6 @@
 #endif
 
 
-using namespace std;
-
 #ifdef _WIN32
 	#include <direct.h>
 	#include "windows.hpp"
@@ -51,6 +49,8 @@ using namespace std;
 	const char FileSystem::PATHSEP = '/';
 #endif
 
+
+using namespace std;
 
 string FileSystem::TMPDIR;
 FileSystem::TemporaryDirectory FileSystem::_tmpdir;


### PR DESCRIPTION
Recently MSYS2 updated gcc11 and texlive-bin started to erroring out


<details><summary> Error Message </summary>

```
In file included from D:/a/_temp/msys64/mingw64/x86_64-w64-mingw32/include/wtypes.h:8,
                   from D:/a/_temp/msys64/mingw64/x86_64-w64-mingw32/include/winscard.h:10,
                   from D:/a/_temp/msys64/mingw64/x86_64-w64-mingw32/include/windows.h:97,
                   from ../../../../../texk/dvisvgm/dvisvgm-src/src/windows.hpp:29,
                   from ../../../../../texk/dvisvgm/dvisvgm-src/src/FileSystem.cpp:41:
  D:/a/_temp/msys64/mingw64/x86_64-w64-mingw32/include/rpcndr.h:64:11: error: reference to 'byte' is ambiguous
     64 |   typedef byte cs_byte;
        |           ^~~~
  In file included from D:/a/_temp/msys64/mingw64/include/c++/11.2.0/bits/stl_algobase.h:61,
                   from D:/a/_temp/msys64/mingw64/include/c++/11.2.0/algorithm:61,
                   from ../../../../../texk/dvisvgm/dvisvgm-src/src/FileSystem.cpp:22:
  D:/a/_temp/msys64/mingw64/include/c++/11.2.0/bits/cpp_type_traits.h:404:30: note: candidates are: 'enum class std::byte'
    404 |   enum class byte : unsigned char;
        |                              ^~~~
  In file included from D:/a/_temp/msys64/mingw64/x86_64-w64-mingw32/include/wtypes.h:8,
                   from D:/a/_temp/msys64/mingw64/x86_64-w64-mingw32/include/winscard.h:10,
                   from D:/a/_temp/msys64/mingw64/x86_64-w64-mingw32/include/windows.h:97,
                   from ../../../../../texk/dvisvgm/dvisvgm-src/src/windows.hpp:29,
                   from ../../../../../texk/dvisvgm/dvisvgm-src/src/FileSystem.cpp:41:
  D:/a/_temp/msys64/mingw64/x86_64-w64-mingw32/include/rpcndr.h:63:25: note:                 'typedef unsigned char byte'
     63 |   typedef unsigned char byte;
        |                         ^~~~
  In file included from D:/a/_temp/msys64/mingw64/x86_64-w64-mingw32/include/wtypes.h:8,
                   from D:/a/_temp/msys64/mingw64/x86_64-w64-mingw32/include/winscard.h:10,
                   from D:/a/_temp/msys64/mingw64/x86_64-w64-mingw32/include/windows.h:97,
                   from ../../../../../texk/dvisvgm/dvisvgm-src/src/windows.hpp:29,
                   from ../../../../../texk/dvisvgm/dvisvgm-src/src/FileSystem.cpp:41:
  D:/a/_temp/msys64/mingw64/x86_64-w64-mingw32/include/rpcndr.h:397:170: error: reference to 'byte' is ambiguous
````

</details>

See https://github.com/msys2/MINGW-packages/runs/3975232287?check_suite_focus=true#step:9:13778

This fixes the build of texlive in https://github.com/msys2/MINGW-packages/pull/9840
I hope this is right place to submit this patch.