### PR TITLE
move transform from <svg> to parent <g> (PS/PDF file clipping)

### DIFF
--- a/src/PsSpecialHandler.cpp
+++ b/src/PsSpecialHandler.cpp
@@ -373,8 +373,17 @@ void PsSpecialHandler::imgfile (FileType filetype, const string &fname, const ma
 
 		// insert element containing the image data
 		matrix.rmultiply(TranslationMatrix(-llx, -lly));  // move lower left corner of image to origin
-		imgNode->setTransform(matrix);
-		_actions->svgTree().appendToPage(std::move(imgNode));
+		if (!clipToBbox) {
+			imgNode->setTransform(matrix);
+			_actions->svgTree().appendToPage(std::move(imgNode));
+		}
+		else {
+			unique_ptr<SVGElement> imgParentNode;
+			imgParentNode = util::make_unique<SVGElement>("g");
+			imgParentNode->append(std::move(imgNode));
+			imgParentNode->setTransform(matrix);
+			_actions->svgTree().appendToPage(std::move(imgParentNode));
+		}
 	}
 	// restore DVI position
 	_actions->setX(x);


### PR DESCRIPTION
This moves the `transform` attribute from an `<svg>` element to a parent `<g>` element. Fixes #178 .