### PR TITLE
configure.ac: fix -Wimplicit-function-declaration

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -55,6 +55,7 @@ AC_CHECK_LIB([kpathsea], [kpse_find_file],,
 
 AC_MSG_CHECKING([kpathsea version])
 AC_RUN_IFELSE([AC_LANG_SOURCE([#include <stdio.h>
+	#include <stdlib.h>
 	#include <kpathsea/kpathsea.h>
 	int main() {
 		FILE *f;


### PR DESCRIPTION
Clang 16 makes -Wimplicit-function-declaration an error by default. We need to include <stdlib.h> for exit().

Signed-off-by: Sam James <sam@gentoo.org>