### PR TITLE
Cleanup obsolete m4 dist hack

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,7 +5,7 @@
 
 AUTOMAKE_OPTIONS = foreign
 EXTRA_DIST = COPYING
-SUBDIRS = libs m4 src tests doc
+SUBDIRS = libs src tests doc
 ACLOCAL_AMFLAGS = -I m4
 
 if USE_BUNDLED_LIBS

--- a/m4/Makefile.am
+++ b/m4/Makefile.am
@@ -1,4 +1,0 @@
-M4_EXTRA_DIST = \
-	ax_check_compile_flag.m4 \
-	ax_code_coverage.m4 \
-	ax_cxx_compile_stdcxx.m4


### PR DESCRIPTION
autoconf & automake, at least nowadays, handle including m4/ correctly in dist tarballs (from `make dist`).

Previously, dist tarballs lacked m4/ax_*.m4 and therefore `autoreconf -fi` would break the Makefile with:
```
make[3]: Entering directory '/var/tmp/portage/app-text/dvisvgm-2.14-r1/work/dvisvgm-2.14/libs/clipper'
Makefile:664: *** missing separator.  Stop.
```

On that line is an unexpanded @CODE_COVERAGE_RULES@.

Bug: https://bugs.gentoo.org/879539
Signed-off-by: Sam James <sam@gentoo.org>