### PR TITLE
add checks for return value of FT_Load_Glyph

### DIFF
--- a/src/FontEngine.cpp
+++ b/src/FontEngine.cpp
@@ -221,7 +221,9 @@ int FontEngine::getHAdvance () const {
 
 int FontEngine::getHAdvance (const Character &c) const {
 	if (_currentFace) {
-		FT_Load_Glyph(_currentFace, charIndex(c), FT_LOAD_NO_SCALE);
+		if (FT_Load_Glyph(_currentFace, charIndex(c), FT_LOAD_NO_SCALE)) {
+            return 0;
+        }
 		return _currentFace->glyph->metrics.horiAdvance;
 	}
 	return 0;
@@ -230,7 +232,9 @@ int FontEngine::getHAdvance (const Character &c) const {
 
 int FontEngine::getVAdvance (const Character &c) const {
 	if (_currentFace) {
-		FT_Load_Glyph(_currentFace, charIndex(c), FT_LOAD_NO_SCALE);
+		if (FT_Load_Glyph(_currentFace, charIndex(c), FT_LOAD_NO_SCALE)) {
+            return 0;
+        }
 		if (FT_HAS_VERTICAL(_currentFace))
 			return _currentFace->glyph->metrics.vertAdvance;
 		return _currentFace->glyph->metrics.horiAdvance;
@@ -241,7 +245,9 @@ int FontEngine::getVAdvance (const Character &c) const {
 
 int FontEngine::getWidth (const Character &c) const {
 	if (_currentFace) {
-		FT_Load_Glyph(_currentFace, charIndex(c), FT_LOAD_NO_SCALE);
+		if (FT_Load_Glyph(_currentFace, charIndex(c), FT_LOAD_NO_SCALE)) {
+            return 0;
+        }
 		return _currentFace->glyph->metrics.width;
 	}
 	return 0;
@@ -250,7 +256,9 @@ int FontEngine::getWidth (const Character &c) const {
 
 int FontEngine::getHeight (const Character &c) const {
 	if (_currentFace) {
-		FT_Load_Glyph(_currentFace, charIndex(c), FT_LOAD_NO_SCALE);
+		if (FT_Load_Glyph(_currentFace, charIndex(c), FT_LOAD_NO_SCALE)) {
+            return 0;
+        }
 		return _currentFace->glyph->metrics.horiBearingY;
 	}
 	return 0;
@@ -259,7 +267,9 @@ int FontEngine::getHeight (const Character &c) const {
 
 int FontEngine::getDepth (const Character &c) const {
 	if (_currentFace) {
-		FT_Load_Glyph(_currentFace, charIndex(c), FT_LOAD_NO_SCALE);
+		if (FT_Load_Glyph(_currentFace, charIndex(c), FT_LOAD_NO_SCALE)) {
+            return 0;
+        }
 		return _currentFace->glyph->metrics.height - _currentFace->glyph->metrics.horiBearingY;
 	}
 	return 0;

--- a/src/FontEngine.cpp
+++ b/src/FontEngine.cpp
@@ -221,10 +221,8 @@ int FontEngine::getHAdvance () const {
 
 int FontEngine::getHAdvance (const Character &c) const {
 	if (_currentFace) {
-		if (FT_Load_Glyph(_currentFace, charIndex(c), FT_LOAD_NO_SCALE)) {
-            return 0;
-        }
-		return _currentFace->glyph->metrics.horiAdvance;
+		if (FT_Load_Glyph(_currentFace, charIndex(c), FT_LOAD_NO_SCALE) == 0)
+			return _currentFace->glyph->metrics.horiAdvance;
 	}
 	return 0;
 }
@@ -232,12 +230,11 @@ int FontEngine::getHAdvance (const Character &c) const {
 
 int FontEngine::getVAdvance (const Character &c) const {
 	if (_currentFace) {
-		if (FT_Load_Glyph(_currentFace, charIndex(c), FT_LOAD_NO_SCALE)) {
-            return 0;
-        }
-		if (FT_HAS_VERTICAL(_currentFace))
-			return _currentFace->glyph->metrics.vertAdvance;
-		return _currentFace->glyph->metrics.horiAdvance;
+		if (FT_Load_Glyph(_currentFace, charIndex(c), FT_LOAD_NO_SCALE) == 0) {
+			if (FT_HAS_VERTICAL(_currentFace))
+				return _currentFace->glyph->metrics.vertAdvance;
+			return _currentFace->glyph->metrics.horiAdvance;
+		}
 	}
 	return 0;
 }
@@ -245,10 +242,8 @@ int FontEngine::getVAdvance (const Character &c) const {
 
 int FontEngine::getWidth (const Character &c) const {
 	if (_currentFace) {
-		if (FT_Load_Glyph(_currentFace, charIndex(c), FT_LOAD_NO_SCALE)) {
-            return 0;
-        }
-		return _currentFace->glyph->metrics.width;
+		if (FT_Load_Glyph(_currentFace, charIndex(c), FT_LOAD_NO_SCALE) == 0)
+			return _currentFace->glyph->metrics.width;
 	}
 	return 0;
 }
@@ -256,10 +251,8 @@ int FontEngine::getWidth (const Character &c) const {
 
 int FontEngine::getHeight (const Character &c) const {
 	if (_currentFace) {
-		if (FT_Load_Glyph(_currentFace, charIndex(c), FT_LOAD_NO_SCALE)) {
-            return 0;
-        }
-		return _currentFace->glyph->metrics.horiBearingY;
+		if (FT_Load_Glyph(_currentFace, charIndex(c), FT_LOAD_NO_SCALE) == 0)
+			return _currentFace->glyph->metrics.horiBearingY;
 	}
 	return 0;
 }
@@ -267,10 +260,8 @@ int FontEngine::getHeight (const Character &c) const {
 
 int FontEngine::getDepth (const Character &c) const {
 	if (_currentFace) {
-		if (FT_Load_Glyph(_currentFace, charIndex(c), FT_LOAD_NO_SCALE)) {
-            return 0;
-        }
-		return _currentFace->glyph->metrics.height - _currentFace->glyph->metrics.horiBearingY;
+		if (FT_Load_Glyph(_currentFace, charIndex(c), FT_LOAD_NO_SCALE) == 0)
+			return _currentFace->glyph->metrics.height - _currentFace->glyph->metrics.horiBearingY;
 	}
 	return 0;
 }


### PR DESCRIPTION
`FT_Load_Glyph` returns a non-zero value if there was any error. This PR adds checks to handle the non-zero return values from `FT_Load_Glyph`.