### PR TITLE
Add initial support for building using CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 3.27)
+
+project(dvisvgm VERSION 3.1.1)
+
+option(BUILD_SHARED "Build code as a shared library" OFF)
+option(BUILD_TESTS "Build tests" ON)
+option(ENABLE_ASAN "Enable AddressSanitizer" OFF)
+option(ENABLE_UBSAN "Enable UndefinedBehaviorSanitizer" OFF)
+
+if (BUILD_SHARED)
+    add_compile_options(-fPIC)
+endif()
+if (ENABLE_ASAN)
+    add_compile_options(-fsanitize=address -Og)
+    add_link_options(-fsanitize=address)
+endif()
+if (ENABLE_UBSAN)
+    add_compile_options(-fsanitize=undefined -Og)
+    add_link_options(-fsanitize=undefined)
+endif()
+
+if (CMAKE_BUILD_TYPE STREQUAL "Release")
+    add_compile_options(-O2)
+endif()
+
+add_subdirectory(libs)
+add_subdirectory(src)
+if (BUILD_TESTS)
+    add_subdirectory(tests)
+endif()

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -1,0 +1,14 @@
+include(FindPkgConfig)
+
+pkg_check_modules(freetype2 REQUIRED freetype2 IMPORTED_TARGET)
+add_library(freetype2 INTERFACE)
+target_link_libraries(freetype2 INTERFACE PkgConfig::freetype2)
+
+add_subdirectory(boost)
+add_subdirectory(brotli)
+add_subdirectory(clipper)
+add_subdirectory(md5)
+add_subdirectory(potrace)
+add_subdirectory(variant)
+add_subdirectory(woff2)
+add_subdirectory(xxHash)

--- a/libs/boost/CMakeLists.txt
+++ b/libs/boost/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_library(boost INTERFACE)
+target_include_directories(boost INTERFACE .)
+target_compile_features(boost INTERFACE cxx_std_11)

--- a/libs/brotli/CMakeLists.txt
+++ b/libs/brotli/CMakeLists.txt
@@ -1,0 +1,39 @@
+pkg_check_modules(brotlienc libbrotlienc IMPORTED_TARGET)
+
+if (NOT brotlienc_FOUND)
+    set(SOURCES
+        common/constants.c
+        common/context.c
+        common/dictionary.c
+        common/platform.c
+        common/transform.c
+        enc/backward_references.c
+        enc/backward_references_hq.c
+        enc/bit_cost.c
+        enc/block_splitter.c
+        enc/brotli_bit_stream.c
+        enc/cluster.c
+        enc/command.c
+        enc/compound_dictionary.c
+        enc/compress_fragment.c
+        enc/compress_fragment_two_pass.c
+        enc/dictionary_hash.c
+        enc/encode.c
+        enc/encoder_dict.c
+        enc/entropy_encode.c
+        enc/fast_log.c
+        enc/histogram.c
+        enc/literal_cost.c
+        enc/memory.c
+        enc/metablock.c
+        enc/static_dict.c
+        enc/utf8_util.c
+    )
+    add_library(brotli ${SOURCES})
+    target_include_directories(brotli PUBLIC include)
+    target_compile_options(brotli PRIVATE -Wall)
+    target_compile_features(brotli PUBLIC cxx_std_11)
+else()
+    add_library(brotli INTERFACE)
+    target_link_libraries(brotli INTERFACE PkgConfig::brotlienc)
+endif()

--- a/libs/clipper/CMakeLists.txt
+++ b/libs/clipper/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_library(clipper clipper.cpp)
+target_include_directories(clipper PUBLIC .)
+target_compile_options(clipper PRIVATE -Wall)
+target_compile_features(clipper PUBLIC cxx_std_11)

--- a/libs/clipper/clipper.cpp
+++ b/libs/clipper/clipper.cpp
@@ -1970,7 +1970,7 @@ void Clipper::DeleteFromSEL(TEdge *e)
 #ifdef use_xyz
 void Clipper::SetZ(IntPoint& pt, TEdge& e1, TEdge& e2)
 {
-  if (pt.Z != 0 || !m_ZFill) return;
+  if (pt.Z != static_cast<ZType>(0) || !m_ZFill) return;
   else if (pt == e1.Bot) pt.Z = e1.Bot.Z;
   else if (pt == e1.Top) pt.Z = e1.Top.Z;
   else if (pt == e2.Bot) pt.Z = e2.Bot.Z;

--- a/libs/md5/CMakeLists.txt
+++ b/libs/md5/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_library(md5 md5.c)
+target_include_directories(md5 PUBLIC .)
+target_compile_options(md5 PRIVATE -Wall)
+target_compile_features(md5 PUBLIC c_std_11)

--- a/libs/potrace/CMakeLists.txt
+++ b/libs/potrace/CMakeLists.txt
@@ -1,0 +1,12 @@
+pkg_check_modules(potrace potrace IMPORTED_TARGET)
+
+if (NOT potrace_FOUND)
+    add_library(potrace curve.c decompose.c potracelib.c trace.c)
+    target_include_directories(potrace PUBLIC .)
+    target_compile_definitions(potrace PRIVATE HAVE_CONFIG_H)
+    target_compile_options(potrace PRIVATE -Wall)
+    target_compile_features(potrace PUBLIC c_std_11)
+else()
+    add_library(potrace INTERFACE)
+    target_link_libraries(potrace INTERFACE PkgConfig::potrace)
+endif()

--- a/libs/variant/CMakeLists.txt
+++ b/libs/variant/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_library(mpark_variant INTERFACE)
+target_include_directories(mpark_variant INTERFACE include)
+target_compile_features(mpark_variant INTERFACE cxx_std_11)

--- a/libs/woff2/CMakeLists.txt
+++ b/libs/woff2/CMakeLists.txt
@@ -1,0 +1,23 @@
+pkg_check_modules(woff2enc libwoff2enc IMPORTED_TARGET)
+
+if (NOT woff2enc_FOUND)
+    set(SOURCES
+        src/font.cc
+        src/glyph.cc
+        src/normalize.cc
+        src/table_tags.cc
+        src/transform.cc
+        src/variable_length.cc
+        src/woff2_common.cc
+        src/woff2_enc.cc
+        src/woff2_out.cc
+    )
+    add_library(woff2 ${SOURCES})
+    target_include_directories(woff2 PUBLIC include)
+    target_compile_options(woff2 PRIVATE -Wall)
+    target_link_libraries(woff2 PRIVATE brotli)
+    target_compile_features(woff2 PUBLIC cxx_std_11)
+else()
+    add_library(woff2 INTERFACE)
+    target_link_libraries(woff2 INTERFACE PkgConfig::woff2enc)
+endif()

--- a/libs/xxHash/CMakeLists.txt
+++ b/libs/xxHash/CMakeLists.txt
@@ -1,0 +1,11 @@
+pkg_check_modules(xxhash libxxhash IMPORTED_TARGET)
+
+if (NOT xxhash_FOUND)
+    add_library(xxhash xxhash.c)
+    target_include_directories(xxhash PUBLIC .)
+    target_compile_options(xxhash PRIVATE -Wall)
+    target_compile_features(xxhash PUBLIC cxx_std_11)
+else()
+    add_library(xxhash INTERFACE)
+    target_link_libraries(xxhash INTERFACE PkgConfig::xxhash)
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,215 @@
+set(SOURCES
+    BasicDVIReader.cpp
+    Bezier.cpp
+    BgColorSpecialHandler.cpp
+    Bitmap.cpp
+    BoundingBox.cpp
+    Calculator.cpp
+    CharMapID.cpp
+    CLCommandLine.cpp
+    CMap.cpp
+    CMapManager.cpp
+    CMapReader.cpp
+    Color.cpp
+    ColorSpecialHandler.cpp
+    Directory.cpp
+    DLLoader.cpp
+    DVIReader.cpp
+    DvisvgmSpecialHandler.cpp
+    DVIToSVG.cpp
+    DVIToSVGActions.cpp
+    EllipticalArc.cpp
+    EmSpecialHandler.cpp
+    EncFile.cpp
+    EPSFile.cpp
+    FileFinder.cpp
+    FilePath.cpp
+    FileSystem.cpp
+    Font.cpp
+    FontCache.cpp
+    FontEncoding.cpp
+    FontEngine.cpp
+    FontManager.cpp
+    FontMap.cpp
+    FontMetrics.cpp
+    fonts/Base14Fonts.cpp
+    fonts/Dingbats.cff.cpp
+    fonts/NimbusMonoPS-Bold.cff.cpp
+    fonts/NimbusMonoPS-BoldItalic.cff.cpp
+    fonts/NimbusMonoPS-Italic.cff.cpp
+    fonts/NimbusMonoPS-Regular.cff.cpp
+    fonts/NimbusRoman-Bold.cff.cpp
+    fonts/NimbusRoman-BoldItalic.cff.cpp
+    fonts/NimbusRoman-Italic.cff.cpp
+    fonts/NimbusRoman-Regular.cff.cpp
+    fonts/NimbusSans-Bold.cff.cpp
+    fonts/NimbusSans-BoldItalic.cff.cpp
+    fonts/NimbusSans-Italic.cff.cpp
+    fonts/NimbusSans-Regular.cff.cpp
+    fonts/StandardSymbolsPS.cff.cpp
+    FontWriter.cpp
+    GFGlyphTracer.cpp
+    GFReader.cpp
+    GFTracer.cpp
+    Ghostscript.cpp
+    HashFunction.cpp
+    HtmlSpecialHandler.cpp
+    HyperlinkManager.cpp
+    ImageToSVG.cpp
+    InputBuffer.cpp
+    InputReader.cpp
+    JFM.cpp
+    Length.cpp
+    MapLine.cpp
+    Matrix.cpp
+    Message.cpp
+    MetafontWrapper.cpp
+    NoPsSpecialHandler.cpp
+    OFM.cpp
+    Opacity.cpp
+    optimizer/AttributeExtractor.cpp
+    optimizer/ClipPathReassigner.cpp
+    optimizer/GroupCollapser.cpp
+    optimizer/RedundantElementRemover.cpp
+    optimizer/SVGOptimizer.cpp
+    optimizer/TextSimplifier.cpp
+    optimizer/TransformSimplifier.cpp
+    optimizer/WSNodeRemover.cpp
+    PageRanges.cpp
+    PageSize.cpp
+    PapersizeSpecialHandler.cpp
+    PathClipper.cpp
+    PDFHandler.cpp
+    PDFParser.cpp
+    PdfSpecialHandler.cpp
+    PDFToSVG.cpp
+    PreScanDVIReader.cpp
+    Process.cpp
+    psdefs.cpp
+    PSInterpreter.cpp
+    PSPattern.cpp
+    PSPreviewHandler.cpp
+    PsSpecialHandler.cpp
+    RangeMap.cpp
+    ShadingPatch.cpp
+    SignalHandler.cpp
+    SourceInput.cpp
+    SpecialManager.cpp
+    StreamReader.cpp
+    StreamWriter.cpp
+    Subfont.cpp
+    SVGCharHandler.cpp
+    SVGCharHandlerFactory.cpp
+    SVGCharPathHandler.cpp
+    SVGCharTspanTextHandler.cpp
+    SVGElement.cpp
+    SVGOutput.cpp
+    SVGSingleCharTextHandler.cpp
+    SVGTree.cpp
+    System.cpp
+    TensorProductPatch.cpp
+    Terminal.cpp
+    TFM.cpp
+    ToUnicodeMap.cpp
+    TpicSpecialHandler.cpp
+    TriangularPatch.cpp
+    ttf/CmapTable.cpp
+    ttf/GlyfTable.cpp
+    ttf/HeadTable.cpp
+    ttf/HheaTable.cpp
+    ttf/HmtxTable.cpp
+    ttf/MaxpTable.cpp
+    ttf/NameTable.cpp
+    ttf/OS2Table.cpp
+    ttf/PostTable.cpp
+    ttf/TTFAutohint.cpp
+    ttf/TTFTable.cpp
+    ttf/TTFWriter.cpp
+    ttf/VheaTable.cpp
+    ttf/VmtxTable.cpp
+    Unicode.cpp
+    utility.cpp
+    VFReader.cpp
+    XMLDocument.cpp
+    XMLNode.cpp
+    XMLParser.cpp
+    XMLString.cpp
+)
+
+# ===== dvisvgm library =====
+if (BUILD_SHARED)
+    add_library(dvisvgm SHARED ${SOURCES})
+else()
+    add_library(dvisvgm ${SOURCES})
+endif()
+
+target_compile_options(dvisvgm PRIVATE -Wall)
+target_link_libraries(dvisvgm PUBLIC boost brotli clipper freetype2 kpathsea md5 mpark_variant potrace woff2 xxhash z)
+target_include_directories(dvisvgm INTERFACE .)
+target_compile_features(dvisvgm PUBLIC cxx_std_11)
+
+include(CheckCXXSourceCompiles)
+check_cxx_source_compiles(
+    "#include <signal.h>
+     struct sigaction test;
+     int main() {}"
+    HAVE_SIGACTION)
+check_cxx_source_compiles(
+    "#include <sys/stat.h>
+     void f() { umask(0); }
+     int main() {}"
+    HAVE_UMASK)
+check_cxx_source_compiles(
+    "int main() { __builtin_clz(1); }"
+    HAVE___BUILTIN_CLZ)
+
+include(CheckIncludeFileCXX)
+CHECK_INCLUDE_FILE_CXX(unistd.h HAVE_UNISTD_H)
+CHECK_INCLUDE_FILE_CXX(sys/time.h HAVE_SYS_TIME_H)
+CHECK_INCLUDE_FILE_CXX(sys/timeb.h HAVE_SYS_TIMEB_H)
+CHECK_INCLUDE_FILE_CXX(termios.h HAVE_TERMIOS_H)
+
+configure_file(config.h.in config.h)
+target_include_directories(dvisvgm PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+
+target_compile_definitions(dvisvgm PUBLIC DVISVGM_CMAKE_BUILD)
+
+
+# ===== dvisvgm executable =====
+add_executable(dvisvgm_exe dvisvgm.cpp)
+target_link_libraries(dvisvgm_exe PRIVATE dvisvgm)
+set_target_properties(dvisvgm_exe PROPERTIES OUTPUT_NAME "dvisvgm")
+
+install(TARGETS dvisvgm_exe)
+
+
+# ===== texmf.cnf =====
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    option(TEXMF_CNF_PATH "Path to texmf.cnf file")
+    option(TEX_DISTRIBUTION_PATH "Path to TeX Live distribution (i. e. /usr/share/texmf-dist)")
+
+    # Try to find determine paths automatically
+    if (NOT TEXMF_CNF_PATH AND NOT TEX_DISTRIBUTION_PATH)
+        execute_process(COMMAND which kpsewhich OUTPUT_VARIABLE kpsewhich_path)
+        execute_process(COMMAND kpsewhich -format=cnf texmf.cnf OUTPUT_VARIABLE texmf_path)
+
+        if (NOT kpsewhich_path STREQUAL "" AND NOT texmf_path STREQUAL "")
+            string(STRIP "${texmf_path}" texmf_stripped_path)
+            set(TEXMF_CNF_PATH "${texmf_stripped_path}" CACHE PATH "" FORCE)
+
+            cmake_path(REMOVE_FILENAME kpsewhich_path OUTPUT_VARIABLE kpsewhich_folder)
+            set(distribution_raw_path "${kpsewhich_folder}/../share/texmf-dist")
+            cmake_path(NORMAL_PATH distribution_raw_path OUTPUT_VARIABLE distribution_path)
+
+            set(TEX_DISTRIBUTION_PATH "${distribution_path}" CACHE PATH "" FORCE)
+        endif()
+    endif()
+
+    if (TEXMF_CNF_PATH AND TEX_DISTRIBUTION_PATH)
+        add_custom_command(OUTPUT "${CMAKE_BINARY_DIR}/texmf.cnf"
+            COMMAND cp "${TEXMF_CNF_PATH}" "${CMAKE_BINARY_DIR}/texmf.cnf"
+            COMMAND sed -i "'s:$$SELFAUTODIR:${TEX_DISTRIBUTION_PATH}/../..:g'" "${CMAKE_BINARY_DIR}/texmf.cnf")
+        add_custom_target(texmf_generation DEPENDS "${CMAKE_BINARY_DIR}/texmf.cnf")
+        add_dependencies(dvisvgm texmf_generation)
+    endif()
+endif()

--- a/src/GraphicsPathParser.hpp
+++ b/src/GraphicsPathParser.hpp
@@ -35,7 +35,7 @@ namespace internal {
 	}
 
 	template <>
-	bool parse_number (std::istream &is, double &value) {
+	inline bool parse_number (std::istream &is, double &value) {
 		// don't use operator >> for parsing floating point values because it's implemented
 		// differently in libstdc++ and libc++. Instead, use our own function to read the
 		// value from the input stream.

--- a/src/Unicode.cpp
+++ b/src/Unicode.cpp
@@ -181,8 +181,13 @@ uint32_t Unicode::toSurrogate (uint32_t cp) {
 
 
 uint32_t Unicode::toLigature (const string &nonlig) {
+#if defined(__cpp_char8_t)
+	using literal_char_type = char8_t;
+#else
+	using literal_char_type = char;
+#endif
 	struct Ligature {
-		const char *nonlig;
+		const literal_char_type *nonlig;
 		uint32_t lig;
 	} ligatures[39] = {
 		{u8"AA",  0xA732}, {u8"aa", 0xA733},
@@ -212,7 +217,7 @@ uint32_t Unicode::toLigature (const string &nonlig) {
 		{u8"VY",  0xA760}, {u8"tz",  0xA761},
 	};
 	auto it = find_if(begin(ligatures), end(ligatures), [&nonlig](const Ligature &l) {
-		return l.nonlig == nonlig;
+		return reinterpret_cast<const char*>(l.nonlig) == nonlig;
 	});
 	return it != end(ligatures) ? it->lig : 0;
 }

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -1,0 +1,32 @@
+/*************************************************************************
+** config.h.in                                                          **
+**                                                                      **
+** This file is part of dvisvgm -- a fast DVI to SVG converter          **
+** Copyright (C) 2005-2023 Martin Gieseking <martin.gieseking@uos.de>   **
+**                                                                      **
+** This program is free software; you can redistribute it and/or        **
+** modify it under the terms of the GNU General Public License as       **
+** published by the Free Software Foundation; either version 3 of       **
+** the License, or (at your option) any later version.                  **
+**                                                                      **
+** This program is distributed in the hope that it will be useful, but  **
+** WITHOUT ANY WARRANTY; without even the implied warranty of           **
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the         **
+** GNU General Public License for more details.                         **
+**                                                                      **
+** You should have received a copy of the GNU General Public License    **
+** along with this program; if not, see <http://www.gnu.org/licenses/>. **
+*************************************************************************/
+
+#ifndef CONFIG_H_IN
+#define CONFIG_H_IN
+
+#cmakedefine HAVE___BUILTIN_CLZ
+#cmakedefine HAVE_SIGACTION
+#cmakedefine HAVE_SYS_TIME_H
+#cmakedefine HAVE_SYS_TIMEB_H
+#cmakedefine HAVE_TERMIOS_H
+#cmakedefine HAVE_UMASK
+#cmakedefine HAVE_UNISTD_H
+
+#endif

--- a/src/fonts/Base14Fonts.hpp
+++ b/src/fonts/Base14Fonts.hpp
@@ -24,7 +24,6 @@
 #include <string>
 
 struct MemoryFontData {
-	MemoryFontData () =delete;
 	const char *data;
 	size_t size;
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,80 @@
+set(SOURCES
+    BezierTest.cpp
+    BitmapTest.cpp
+    BoundingBoxTest.cpp
+    CMapManagerTest.cpp
+    CMapReaderTest.cpp
+    CMapTest.cpp
+    CalculatorTest.cpp
+    ColorSpecialTest.cpp
+    ColorTest.cpp
+    CommandLineTest.cpp
+    DVIReaderTest.cpp
+    DependencyGraphTest.cpp
+    DirectoryTest.cpp
+    DvisvgmSpecialTest.cpp
+    EllipticalArcTest.cpp
+    EmSpecialTest.cpp
+    FileFinderTest.cpp
+    FilePathTest.cpp
+    FileSystemTest.cpp
+    FontCacheTest.cpp
+    FontManagerTest.cpp
+    FontMapTest.cpp
+    GFGlyphTracerTest.cpp
+    GFReaderTest.cpp
+    GhostscriptTest.cpp
+    GraphicsPathParserTest.cpp
+    GraphicsPathTest.cpp
+    HashFunctionTest.cpp
+    JFMReaderTest.cpp
+    LengthTest.cpp
+    MapLineTest.cpp
+    MatrixTest.cpp
+    MessageExceptionTest.cpp
+    OFMReaderTest.cpp
+    PDFParserTest.cpp
+    PSInterpreterTest.cpp
+    PageRagesTest.cpp
+    PageSizeTest.cpp
+    PairTest.cpp
+    PapersizeSpecialTest.cpp
+    RangeMapTest.cpp
+    SVGOutputTest.cpp
+    ShadingPatchTest.cpp
+    SpecialManagerTest.cpp
+    SplittedCharInputBufferTest.cpp
+    StreamInputBufferTest.cpp
+    StreamReaderTest.cpp
+    StreamWriterTest.cpp
+    StringMatcherTest.cpp
+    SubfontTest.cpp
+    TFMReaderTest.cpp
+    TensorProductPatchTest.cpp
+    ToUnicodeMapTest.cpp
+    TpicSpecialTest.cpp
+    TriangularPatchTest.cpp
+    UnicodeTest.cpp
+    UtilityTest.cpp
+    VectorIteratorTest.cpp
+    VectorStreamTest.cpp
+    XMLNodeTest.cpp
+    XMLStringTest.cpp
+    testmain.cpp
+)
+
+set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
+
+include(FetchContent)
+include(GoogleTest)
+
+FetchContent_Declare(googletest URL https://github.com/google/googletest/archive/v1.14.0.zip)
+FetchContent_MakeAvailable(googletest)
+
+add_executable(UnitTests ${SOURCES})
+target_link_libraries(UnitTests PRIVATE dvisvgm GTest::gtest)
+# Modern googletest requires at least C++17
+target_compile_features(UnitTests PRIVATE cxx_std_17)
+gtest_discover_tests(UnitTests)
+
+target_compile_definitions(UnitTests PRIVATE SRCDIR="${CMAKE_CURRENT_SOURCE_DIR}")

--- a/tests/TensorProductPatchTest.cpp
+++ b/tests/TensorProductPatchTest.cpp
@@ -265,7 +265,7 @@ TEST_F(TensorProductPatchTest, bbox) {
 }
 
 
-class Callback : public ShadingPatch::Callback {
+class TensorProductPatchTestCallback : public ShadingPatch::Callback {
 	public:
 		void patchSegment (GraphicsPath<double> &path, const Color &color) {
 			ostringstream oss;
@@ -284,7 +284,7 @@ class Callback : public ShadingPatch::Callback {
 
 
 TEST_F(TensorProductPatchTest, approximate) {
-	Callback callback;
+	TensorProductPatchTestCallback callback;
 	vector<Color> colors(4);
 	TensorProductPatch tpp(_points, colors, Color::ColorSpace::RGB, 0, 0);
 	tpp.approximate(2, false, 0.1, callback);

--- a/tests/TriangularPatchTest.cpp
+++ b/tests/TriangularPatchTest.cpp
@@ -142,7 +142,7 @@ TEST(TriangularPatchTest, boundaryPath) {
 }
 
 
-class Callback : public ShadingPatch::Callback {
+class TriangularPatchTestCallback : public ShadingPatch::Callback {
 	public:
 		void patchSegment (GraphicsPath<double> &path, const Color &color) {
 			ostringstream oss;
@@ -167,7 +167,7 @@ TEST(TriangularPatchTest, approximate) {
 	points[2] = DPair(0, 10);
 	vector<Color> colors(3);
 	TriangularPatch tp(points, colors, Color::ColorSpace::RGB, 0, 0);
-	Callback callback;
+	TriangularPatchTestCallback callback;
 	tp.approximate(2, false, 0.1, callback);
 	EXPECT_EQ(callback.pathstr(), "M0 0H10L0 10Z");
 	EXPECT_EQ(callback.colorstr(), "#000");

--- a/tests/testutil.hpp
+++ b/tests/testutil.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
+#ifndef DVISVGM_CMAKE_BUILD
 #define WARNING(...) \
 	ColoredPrintf(testing::internal::GTestColor::kYellow, "[ WARNING  ] "), \
 	ColoredPrintf(testing::internal::GTestColor::kYellow, __VA_ARGS__), \
 	printf("\n")
-
+#else
+#define WARNING(...)
+#endif


### PR DESCRIPTION
This adds limited support for building project using CMake and, crucially for me, support for building code as a shared library.

Feel free to close the PR if the maintenance burden for the CMake build will be too high. Honestly, I just haven't felt like troubleshooting autotools after configuring failed with some obscure error.

For some context, I want to use DVI parser from here in my attempt to speed up LaTeX live previews (in Sublime Text). The current idea is to fork `latex` process right before it reads `\begin{document}` (this part is simple and already done); use the fork to produce dvi file with a rendered preview; split it into glyphs using `dvisvgm`; and then rerender changed parts (probably, using [this](https://github.com/atilimcetin/path-rendering) library).