### PR TITLE
Add missing `<cstdint>` includes 

### DIFF
--- a/src/Character.hpp
+++ b/src/Character.hpp
@@ -21,6 +21,7 @@
 #ifndef CHARACTER_HPP
 #define CHARACTER_HPP
 
+#include <cstdint>
 
 class Character {
 	public:

--- a/src/HashFunction.hpp
+++ b/src/HashFunction.hpp
@@ -21,6 +21,7 @@
 #ifndef HASHFUNCTION_HPP
 #define HASHFUNCTION_HPP
 
+#include <cstdint>
 #include <istream>
 #include <memory>
 #include <string>

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -25,6 +25,7 @@
 #include <config.h>
 #endif
 
+#include <cstdint>
 #include <iomanip>
 #include <functional>
 #include <memory>


### PR DESCRIPTION
`uint8_t`, `uint32_t` are used without including `<cstdint>` which fails to build w/ GCC 15 after a change in libstdc++ [0]

[0] https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=3a817a4a5a6d94da9127af3be9f84a74e3076ee2