### PR TITLE
FontEngine: handle FT_Init_FreeType failure

### DIFF
--- a/src/FontEngine.cpp
+++ b/src/FontEngine.cpp
@@ -56,7 +56,6 @@ static inline FT_Fixed to_16dot16 (int val) {
 FontEngine::FontEngine () {
     if (FT_Init_FreeType(&_library)) {
         Message::estream(true) << "failed to initialize FreeType library\n";
-        _library = nullptr;
     }
 }
 

--- a/src/FontEngine.cpp
+++ b/src/FontEngine.cpp
@@ -54,16 +54,18 @@ static inline FT_Fixed to_16dot16 (int val) {
 
 
 FontEngine::FontEngine () {
-	if (FT_Init_FreeType(&_library))
-		Message::estream(true) << "failed to initialize FreeType library\n";
+    if (FT_Init_FreeType(&_library)) {
+        Message::estream(true) << "failed to initialize FreeType library\n";
+        _library = nullptr;
+    }
 }
 
 
 FontEngine::~FontEngine () {
-	if (_currentFace && FT_Done_Face(_currentFace))
-		Message::estream(true) << "failed to release font\n";
-	if (FT_Done_FreeType(_library))
-		Message::estream(true) << "failed to release FreeType library\n";
+    if (_currentFace && FT_Done_Face(_currentFace))
+        Message::estream(true) << "failed to release font\n";
+    if (_library && FT_Done_FreeType(_library))
+        Message::estream(true) << "failed to release FreeType library\n";
 }
 
 

--- a/src/FontEngine.cpp
+++ b/src/FontEngine.cpp
@@ -54,17 +54,16 @@ static inline FT_Fixed to_16dot16 (int val) {
 
 
 FontEngine::FontEngine () {
-    if (FT_Init_FreeType(&_library)) {
-        Message::estream(true) << "failed to initialize FreeType library\n";
-    }
+	if (FT_Init_FreeType(&_library))
+		Message::estream(true) << "failed to initialize FreeType library\n";
 }
 
 
 FontEngine::~FontEngine () {
-    if (_currentFace && FT_Done_Face(_currentFace))
-        Message::estream(true) << "failed to release font\n";
-    if (_library && FT_Done_FreeType(_library))
-        Message::estream(true) << "failed to release FreeType library\n";
+	if (_currentFace && FT_Done_Face(_currentFace))
+		Message::estream(true) << "failed to release font\n";
+	if (_library && FT_Done_FreeType(_library))
+		Message::estream(true) << "failed to release FreeType library\n";
 }
 
 


### PR DESCRIPTION
Hi, this pull request adds nullptr check for `_library ` before calling FT_Done_FreeType in FontEngine.

I found that when FT_Init_FreeType fails, `_library ` is still being passed to FT_Done_FreeType(), which causes a nullptr dereference in FT_Done_FreeType. This is found when testing FreeType failure paths with software fault injection.

Let me know if you need more information!