### PR TITLE
fix: resolve three bugs in font lookup, subfont parsing, and PDF parsing

### DIFF
--- a/src/FontManager.cpp
+++ b/src/FontManager.cpp
@@ -307,10 +307,9 @@ int FontManager::registerFont (uint32_t fontnum, const string &filename, int fon
 	else {
 		if (!FileSystem::exists(path)) {
 			const char *fontFormats[] = {nullptr, "otf", "ttf"};
-			auto it = algo::find_if(fontFormats, [&](const char *format) {
-				return FileFinder::instance().lookup(filename, format, false) != nullptr;
+			algo::find_if(fontFormats, [&](const char *format) {
+				return (path = FileFinder::instance().lookup(filename, format, false)) != nullptr;
 			});
-			path = it != end(fontFormats) ? *it : nullptr;
 		}
 		if (path) {
 			newfont.reset(new NativeFontImpl(path, fontIndex, ptsize, style, color));

--- a/src/PDFParser.cpp
+++ b/src/PDFParser.cpp
@@ -285,11 +285,12 @@ static PDFIndirectObject parse_indirect_object (InputReader &ir, const char *del
 	while (ir.peek() >= 0 && !strchr(delim, ir.peek()));  // ensure delimiter after "endobj"
 	if (objects.size() >= 2) {
 		const int *genno = objects.back().get<int>();
-		objects.pop_back();
-		const int *objno = objects.back().get<int>();
-		objects.pop_back();
-		if (objno && genno)
+		const int *objno = objects[objects.size()-2].get<int>();
+		if (objno && genno) {
+			objects.pop_back();
+			objects.pop_back();
 			return {*objno, *genno};
+		}
 	}
 	throw PDFException("object and generation number expected before 'obj'");
 }
@@ -298,11 +299,12 @@ static PDFIndirectObject parse_indirect_object (InputReader &ir, const char *del
 static PDFObjectRef parse_object_ref (vector<PDFObject> &objects) {
 	if (objects.size() >= 2) {
 		const int *genno = objects.back().get<int>();
-		objects.pop_back();
-		const int *objno = objects.back().get<int>();
-		objects.pop_back();
-		if (objno && genno)
+		const int *objno = objects[objects.size()-2].get<int>();
+		if (objno && genno) {
+			objects.pop_back();
+			objects.pop_back();
 			return {*objno, *genno};
+		}
 	}
 	throw PDFException("object and generation number expected before 'R'");
 }

--- a/src/Subfont.cpp
+++ b/src/Subfont.cpp
@@ -184,7 +184,9 @@ static int skip_mapping_data (istream &is) {
 		is.getline(buf, 1024);
 		if (is.gcount() > 1)
 			lines++;
-		const char *p = buf+is.gcount()-2;
+		const char *p = buf;
+		if (is.gcount() >= 2)
+			p = buf+is.gcount()-2;
 		while (p >= buf && isspace(*p))
 			p--;
 		complete = (p < buf || *p != '\\');  // line doesn't end with backslash


### PR DESCRIPTION
- FontManager: capture actual resolved path from FileFinder::lookup instead of storing the format array element (nullptr for exact match)
- Subfont: avoid forming pointer before array when gcount() < 2
- PDFParser: validate object types before popping from vector